### PR TITLE
Fix build error with new 'make' utility versions

### DIFF
--- a/linux-2.6.x/drivers/media/dvb/b2c2/Makefile
+++ b/linux-2.6.x/drivers/media/dvb/b2c2/Makefile
@@ -1,6 +1,6 @@
 obj-b2c2-usb = b2c2-usb-core.o b2c2-common.o
 
 obj-$(CONFIG_DVB_B2C2_SKYSTAR) += skystar2.o
-obj-$(CONFIG_DVB_B2C2_USB) + = b2c2-usb.o
+obj-$(CONFIG_DVB_B2C2_USB) += b2c2-usb.o
 
 EXTRA_CFLAGS = -Idrivers/media/dvb/dvb-core/ -Idrivers/media/dvb/frontends/


### PR DESCRIPTION
Error:
    drivers/media/dvb/b2c2/Makefile:4: *** missing separator.  Stop.